### PR TITLE
chore: clean up editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,16 +4,18 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 4
+indent_size = unset
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.js]
+indent_size = 2
 
 [*.json]
 indent_size = 2
 
-[*.{yml,yaml}]
-indent_size = 2
-trim_trailing_whitespace = false
-
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * JavaScriptとYAMLのインデントを2スペースに統一。YAMLの独自トレーリングスペース設定を削除。既存の改行・文字コード・最終行改行ポリシーは維持。
* **Chores**
  * EditorConfigを再編し、言語別ルールを明確化。プロジェクト全体のコーディングスタイルの一貫性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->