### PR TITLE
chore: update markdownlint config

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,5 +2,9 @@
 
 default: true
 
+MD013: false
+
 MD024:
   siblings_only: true
+
+MD029: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - MarkdownLint 設定を更新し、MD013（行長）と MD029（番号付きリスト）を無効化。既存の MD024 と default 設定は維持。
  - ドキュメントの lint ノイズを削減し、執筆・レビューを円滑化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->