### PR TITLE
chore: disable document-start rule

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,5 +3,6 @@
 extends: default
 
 rules:
+  document-start: disable
   line-length: disable
   truthy: disable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - YAML のリント設定を調整し、document-start に関するチェックを無効化しました。
  - 既存の line-length や truthy などのルールはそのまま維持されます。ユーザー向けの機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->