### PR TITLE
chore: remove run-name from workflows

### DIFF
--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -2,7 +2,6 @@ name: preset-pr
 on:
   pull_request:
     types: [opened, reopened]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - CI ワークフローの設定を整理し、実行名の指定を削除。動作や権限、並行実行、プルリクエストのトリガー設定には影響ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->