### PR TITLE
chore: switch renovate schedule to daily cron window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["after 10am and before 1pm on saturday"],
+  "schedule": ["* 10-21 * * *"],
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Renovate設定のスケジュールを更新しました。自動更新トリガーの実行時間を、土曜日のみ午前10時〜午後1時から、毎日午前10時〜午後9時に変更。更新がより広い時間帯で実行されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->